### PR TITLE
Removing component from entity removes entity only from proper systems' self.target[category] list (by removed component).

### DIFF
--- a/src/engine.lua
+++ b/src/engine.lua
@@ -249,7 +249,7 @@ function Engine.componentRemoved(self, event)
     -- Removing Entity from old systems
     if self.allRequirements[component] then
         for index, system in pairs(self.allRequirements[component]) do 
-            system:removeEntity(entity)
+            system:removeEntity(entity, component)
         end
     end
 end

--- a/src/system.lua
+++ b/src/system.lua
@@ -25,14 +25,23 @@ function System:addEntity(entity, category)
     end
 end
 
-function System:removeEntity(entity)
+function System:removeEntity(entity, component)
     if table.firstElement(self.targets) then
         if table.firstElement(self.targets).__name then
             self.targets[entity.id] = nil
         else
             -- Removing entities from their respective category target list.
             for index, _ in pairs(self.targets) do
-                self.targets[index][entity.id] = nil
+                if component then
+                    for _, req in pairs(self:requires()[index]) do
+                        if req == component then
+                            self.targets[index][entity.id] = nil
+                            break
+                        end
+                    end
+                else
+                    self.targets[index][entity.id] = nil
+                end
             end
         end
     end

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,54 @@
+require 'lovetoys'
+
+function len(t)
+  local c = 0
+  for _, _ in pairs(t) do
+  	c = c + 1
+  end
+  return c
+end
+
+-- character, type1, type2, active
+C, T1, T2, A = class('C', Component), class('T1', Component), class('T2', Component), class('A', Component)
+
+local e1, e2 = Entity(), Entity()
+
+
+-- type 1 character who is active
+e1:add(C())
+e1:add(T1())
+e1:add(A())
+
+-- type 2 character, not active
+e2:add(C())
+e2:add(T2())
+
+
+local S = class('S', System)
+
+function S:draw() end
+
+function S:requires() 
+  return {activeCharacters = {'A'}, allCharacters = {'C'}}
+end
+
+local s = S()
+
+local engine = Engine()
+engine:addSystem(s)
+
+engine:addEntity(e1)
+engine:addEntity(e2)
+
+assert(1 == len(s.targets.activeCharacters))
+assert(2 == len(s.targets.allCharacters))
+
+-- make e1 non-active
+e1:remove('A')
+assert(0 == len(s.targets.activeCharacters))
+assert(2 == len(s.targets.allCharacters))
+
+-- mark e2 as active
+e2:add(A())
+assert(1 == len(s.targets.activeCharacters))
+assert(2 == len(s.targets.allCharacters))


### PR DESCRIPTION
Hi there,

Have a look at the test.lua - in your current version it does not work since removing component from entity caused entity to be removed from all categories of all systems.

With PR below entity is removed only from matching categories.  