### PR TITLE
Added Engine:getSystem(name)

### DIFF
--- a/src/engine.lua
+++ b/src/engine.lua
@@ -215,6 +215,14 @@ function Engine:toggleSystem(name)
     end
 end
 
+function Engine:getSystem(name)
+    for index, system in pairs(self.systems["all"]) do
+        if name == system.__name then
+            return system
+        end
+    end
+end
+
 function Engine:update(dt)
     for index, system in ipairs(self.systems["update"]) do
         if system.active then


### PR DESCRIPTION
Might be useful from time to time. And does not require one to create local variables, so instead of 

````lua
local xSystem = XSystem()
engine:addSystem(xSystem)

xSystem:doSomething()
```

one can:

````lua
engine:addSystem(XSystem())
-- and somewhere else
engine:getSystem('XSystem'):doSomething()
```


BTW, I think there should be one more table indexed by system.__name for faster access.