### PR TITLE
table.firstElement() use next() rather than loop via pairs and remove…

### DIFF
--- a/lovetoys.lua
+++ b/lovetoys.lua
@@ -6,6 +6,9 @@ lovetoyDebug = false
 -- Requiring class
 require(folderOfThisFile .. "src/class")
 
+-- Requiring util functions
+require(folderOfThisFile .. "src/util")
+
 -- Requiring all Events
 require(folderOfThisFile .. "src/events/ComponentAdded")
 require(folderOfThisFile .. "src/events/ComponentRemoved")

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -1,9 +1,3 @@
-function table.firstElement(list)
-    for index, value in pairs(list) do
-        return value
-    end
-end
-
 Engine = class("Engine")
 
 function Engine:__init() 

--- a/src/System.lua
+++ b/src/System.lua
@@ -1,9 +1,3 @@
-function table.firstElement(list)
-    for index, value in pairs(list) do
-        return value
-    end
-end
-
 System = class("System")
 
 function System:__init()

--- a/src/util.lua
+++ b/src/util.lua
@@ -1,0 +1,4 @@
+function table.firstElement(list)
+    local _, value = next(list)
+    return value
+end


### PR DESCRIPTION
… duplicated implementation.

TODO: should not modify the global `table`.