### PR TITLE
Cleanup CI build log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ install:
   - sudo apt-get update
   - sudo apt-get install luajit
   - sudo apt-get install luarocks
-  - sudo luarocks install luafilesystem
   - sudo luarocks install busted
 
-script: "busted"
+before_script:
+  - busted --version
+
+script:
+  - busted --output=TAP
 
 notifications:
   recipients:


### PR DESCRIPTION
- Removed unnecessary quotations.
- Removed the installation of luafilesystem. Busted already defines luafilesystem as a dependency in its rockspec so explicitly installing luafilesystem beforehand is redundant.
- Output busted version before tests. It is standard to echo version of tools before they're ran for ease of debugging if the version of the tool can vary.
- Switch output mode of busted to TAP for readability purposes.