### PR TITLE
Added code coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,18 @@ install:
 
 before_script:
   - luarocks install busted
+  - luarocks install luacov-coveralls
   - busted --version
 
 script:
-  - busted --output=TAP
+  - busted --coverage --output=TAP
 
 cache:
   directories:
     - $PWD/lua_installations
+
+after_success:
+  - luacov-coveralls
 
 notifications:
   recipients:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </div>
 <h1 align="center">Lövetoys</h1>
-[![Build Status](https://travis-ci.org/lovetoys/lovetoys.svg?branch=master)](https://travis-ci.org/lovetoys/lovetoys)
+[![Build Status](https://travis-ci.org/lovetoys/lovetoys.svg?branch=master)](https://travis-ci.org/lovetoys/lovetoys) [![Coverage Status](https://coveralls.io/repos/github/lovetoys/lovetoys/badge.svg?branch=master)](https://coveralls.io/github/lovetoys/lovetoys?branch=master)
 
 `v0.2`
 


### PR DESCRIPTION
This will add statistics pertaining to the amount of code covered by the automated tests. This reporting will not work until the repository is added to https://coveralls.io/