### PR TITLE
Allow lovetoys to be used with any class library

### DIFF
--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -52,8 +52,10 @@ end
 
 function Engine:removeEntity(entity, removeChildren, newParent)
     if self.entities[entity.id] then
+        local components = entity:getComponents()
+
         -- Removing the Entity from all Systems and engine
-        for _, component in pairs(entity:getComponents()) do
+        for _, component in pairs(components) do
             local name = component.class.name
             if self.singleRequirements[name] then
                 for _, system in pairs(self.singleRequirements[name]) do
@@ -62,18 +64,19 @@ function Engine:removeEntity(entity, removeChildren, newParent)
             end
         end
         -- Deleting the Entity from the specific entity lists
-        for _, component in pairs(entity:getComponents()) do
+        for _, component in pairs(components) do
             self.entityLists[component.class.name][entity.id] = nil
         end
 
         -- If removeChild is defined, all children become deleted recursively
+        local children = entity:getChildren()
         if removeChildren then
-            for _, child in pairs(entity:getChildren()) do
+            for _, child in pairs(children) do
                 self:removeEntity(child, true)
             end
         else
             -- If a new Parent is defined, this Entity will be set as the new Parent
-            for _, child in pairs(entity:getChildren()) do
+            for _, child in pairs(children) do
                 if newParent then
                     child:setParent(newParent)
                 else

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -84,9 +84,9 @@ function Engine:removeEntity(entity, removeChildren, newParent)
             end
         end
         -- Removing Reference to entity from parent
-        local parent = entity:getParent()
-        for _, _ in pairs(parent:getChildren()) do
-            parent:getChildren()[entity.id] = nil
+        local siblings = entity:getParent():getChildren()
+        for _, _ in pairs(siblings) do
+            siblings[entity.id] = nil
         end
         -- Setting status of entity to dead. This is for other systems, which still got a hard reference on this
         self.entities[entity.id].alive = false

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -85,8 +85,8 @@ function Engine:removeEntity(entity, removeChildren, newParent)
         end
         -- Removing Reference to entity from parent
         local parent = entity:getParent()
-        for _, _ in pairs(parent.children) do
-            parent.children[entity.id] = nil
+        for _, _ in pairs(parent:getChildren()) do
+            parent:getChildren()[entity.id] = nil
         end
         -- Setting status of entity to dead. This is for other systems, which still got a hard reference on this
         self.entities[entity.id].alive = false
@@ -192,14 +192,14 @@ function Engine:registerSystem(system)
                 end
             end
             -- Create tables for multiple requirements in the system's target directory
-            system.targets[index] = {}
+            system:getTargets()[index] = {}
         end
     end
 end
 
 function Engine:stopSystem(name)
     if self.systemRegistry[name] then
-        self.systemRegistry[name].active = false
+        self.systemRegistry[name]:setActive(false)
     else
         lovetoys.debug("Engine: Trying to stop not existing System: " .. name)
     end
@@ -207,7 +207,7 @@ end
 
 function Engine:startSystem(name)
     if self.systemRegistry[name] then
-        self.systemRegistry[name].active = true
+        self.systemRegistry[name]:setActive(true)
     else
         lovetoys.debug("Engine: Trying to start not existing System: " .. name)
     end
@@ -215,7 +215,7 @@ end
 
 function Engine:toggleSystem(name)
     if self.systemRegistry[name] then
-        self.systemRegistry[name].active = not self.systemRegistry[name].active
+        self.systemRegistry[name]:toggleActive()
     else
         lovetoys.debug("Engine: Trying to toggle not existing System: " .. name)
     end
@@ -223,7 +223,7 @@ end
 
 function Engine:update(dt)
     for _, system in ipairs(self.systems["update"]) do
-        if system.active then
+        if system:isActive() then
             system:update(dt)
         end
     end
@@ -231,7 +231,7 @@ end
 
 function Engine:draw()
     for _, system in ipairs(self.systems["draw"]) do
-        if system.active then
+        if system:isActive() then
             system:draw()
         end
     end

--- a/src/Entity.lua
+++ b/src/Entity.lua
@@ -81,7 +81,7 @@ function Entity:get(name)
 end
 
 function Entity:has(name)
-    return not not self.components[name]
+    return not not self:get(name)
 end
 
 function Entity:getComponents()

--- a/src/Entity.lua
+++ b/src/Entity.lua
@@ -59,7 +59,7 @@ function Entity:remove(name)
 end
 
 function Entity:setParent(parent)
-    if self.parent then self.parent.children[self.id] = nil end
+    if self.parent then self.parent:getChildren()[self.id] = nil end
     self.parent = parent
     self:registerAsChild()
 end
@@ -69,7 +69,11 @@ function Entity:getParent()
 end
 
 function Entity:registerAsChild()
-    if self.id then self.parent.children[self.id] = self end
+    if self.id then self.parent:getChildren()[self.id] = self end
+end
+
+function Entity:getChildren()
+    return self.children
 end
 
 function Entity:get(name)

--- a/src/System.lua
+++ b/src/System.lua
@@ -20,8 +20,7 @@ function System:setActive(isActive)
 end
 
 function System:toggleActive()
-    self.active = not self.active
-    return self.active
+    return self:setActive(not self:isActive())
 end
 
 function System:isActive() return self.active end

--- a/src/System.lua
+++ b/src/System.lua
@@ -12,6 +12,20 @@ end
 
 function System:requires() return {} end
 
+function System:getTargets() return self.targets end
+
+function System:setActive(isActive)
+    self.active = isActive
+    return self.active
+end
+
+function System:toggleActive()
+    self.active = not self.active
+    return self.active
+end
+
+function System:isActive() return self.active end
+
 function System:addEntity(entity, category)
     -- If there are multiple requirement lists, the added entities will
     -- be added to their respetive list.


### PR DESCRIPTION
I added and used some accessor methods instead of accessing/changing properties directly.  This lets people use lovetoys with any arbitrary class framework, rather than forcing them to use Middleclass.  Yes, technically calling a function is slower than accessing a property directly, but this is quite minimal, and the ends justify the means.

I made these changes so that I could use it with the class framework in Moonscript, and it has been working well.
