### PR TITLE
Named components

### DIFF
--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -35,8 +35,7 @@ function Engine:addEntity(entity)
     end
     entity:registerAsChild()
 
-    for _, component in pairs(entity.components) do
-        local name = component.class.name
+    for name, component in pairs(entity.components) do
         -- Adding Entity to specific Entitylist
         if not self.entityLists[name] then self.entityLists[name] = {} end
         self.entityLists[name][entity.id] = entity
@@ -53,8 +52,7 @@ end
 function Engine:removeEntity(entity, removeChildren, newParent)
     if self.entities[entity.id] then
         -- Removing the Entity from all Systems and engine
-        for _, component in pairs(entity.components) do
-            local name = component.class.name
+        for name, component in pairs(entity.components) do
             if self.singleRequirements[name] then
                 for _, system in pairs(self.singleRequirements[name]) do
                     system:removeEntity(entity)
@@ -62,8 +60,8 @@ function Engine:removeEntity(entity, removeChildren, newParent)
             end
         end
         -- Deleting the Entity from the specific entity lists
-        for _, component in pairs(entity.components) do
-            self.entityLists[component.class.name][entity.id] = nil
+        for name, component in pairs(entity.components) do
+            self.entityLists[name][entity.id] = nil
         end
 
         -- If removeChild is defined, all children become deleted recursively

--- a/src/Entity.lua
+++ b/src/Entity.lua
@@ -19,8 +19,8 @@ end
 
 -- Sets the entities component of this type to the given component.
 -- An entity can only have one Component of each type.
-function Entity:add(component)
-    local name = component.class.name
+function Entity:add(component, name)
+    if not name then name = component.class.name end
     if self.components[name] then
         lovetoys.debug("Entity: Trying to add Component '" .. name .. "', but it's already existing. Please use Entity:set to overwrite a component in an entity.")
     else
@@ -31,8 +31,8 @@ function Entity:add(component)
     end
 end
 
-function Entity:set(component)
-    local name = component.class.name
+function Entity:set(component, name)
+    if not name then name = component.class.name end
     if self.components[name] == nil then
         self:add(component)
     else
@@ -41,7 +41,7 @@ function Entity:set(component)
 end
 
 function Entity:addMultiple(componentList)
-    for _, component in  pairs(componentList) do
+    for _, component in pairs(componentList) do
         self:add(component)
     end
 end

--- a/src/Entity.lua
+++ b/src/Entity.lua
@@ -34,7 +34,7 @@ end
 function Entity:set(component, name)
     if not name then name = component.class.name end
     if self.components[name] == nil then
-        self:add(component)
+        self:add(component, name)
     else
         self.components[name] = component
     end


### PR DESCRIPTION
These changes allow components to be named, rather than making them always be the class name. The name still defaults to the class name, and thus this is not a breaking change.

Let's say we have a `Point` component. With these changes, we can do something like the following:

``` lua
player:add(Point(10, 50), 'position')
player:add(Point(30, 50), 'goal')

local position = player:get('position')
```

Before these changes, a different class would need to be created for each of those, `PositionPoint` and `GoalPoint`, because otherwise they would be added with `point.class.name`, which is `'Point'`. But they are just instances of points, and there is therefore no need for this extra complexity.
