### PR TITLE
Entity removal broken for instance of Entity subclass

### DIFF
--- a/src/System.lua
+++ b/src/System.lua
@@ -29,9 +29,9 @@ function System:removeEntity(entity, component)
     -- Get the first element and check if it's a component name
     -- In case it is an Entity, we know that this System doesn't have multiple
     -- Requirements. Otherwise we remove the Entity from each category.
-    local firstElement = lovetoys.util.firstElement(self.targets)
-    if firstElement then
-        if type(firstElement) == "string" then
+    local firstIndex, _ = next(self.targets)
+    if firstIndex then
+        if type(firstIndex) == "string" then
             -- Removing entities from their respective category target list.
             for index, _ in pairs(self.targets) do
                 self.targets[index][entity.id] = nil
@@ -40,15 +40,16 @@ function System:removeEntity(entity, component)
             self.targets[entity.id] = nil
         end
     end
+
 end
 
 function System:componentRemoved(entity, component)
     -- Get the first element and check if it's a component name
     -- In case a System has multiple requirements we need to check for
     -- each requirement category if the entity has to be removed.
-    local firstElement = lovetoys.util.firstElement(self.targets)
-    if firstElement then
-        if type(firstElement) == "string" then
+    local firstIndex, _ = next(self.targets)
+    if firstIndex then
+        if type(firstIndex) == "string" then
             -- Removing entities from their respective category target list.
             for index, _ in pairs(self.targets) do
                 for _, req in pairs(self:requires()[index]) do

--- a/src/System.lua
+++ b/src/System.lua
@@ -26,31 +26,29 @@ function System:addEntity(entity, category)
 end
 
 function System:removeEntity(entity, component)
-    -- Get the first element and check .class.name == 'Entity'
+    -- Get the first element and check if it's a component name
     -- In case it is an Entity, we know that this System doesn't have multiple
     -- Requirements. Otherwise we remove the Entity from each category.
     local firstElement = lovetoys.util.firstElement(self.targets)
     if firstElement then
-        if firstElement.class and firstElement.class.name == 'Entity' then
-            self.targets[entity.id] = nil
-        else
+        if type(firstElement) == "string" then
             -- Removing entities from their respective category target list.
             for index, _ in pairs(self.targets) do
                 self.targets[index][entity.id] = nil
             end
+        else
+            self.targets[entity.id] = nil
         end
     end
 end
 
 function System:componentRemoved(entity, component)
-    -- Get the first element and check .class.name == 'Entity'.
+    -- Get the first element and check if it's a component name
     -- In case a System has multiple requirements we need to check for
     -- each requirement category if the entity has to be removed.
     local firstElement = lovetoys.util.firstElement(self.targets)
     if firstElement then
-        if firstElement.class and firstElement.class.name == 'Entity' then
-            self.targets[entity.id] = nil
-        else
+        if type(firstElement) == "string" then
             -- Removing entities from their respective category target list.
             for index, _ in pairs(self.targets) do
                 for _, req in pairs(self:requires()[index]) do
@@ -60,6 +58,8 @@ function System:componentRemoved(entity, component)
                     end
                 end
             end
+        else
+            self.targets[entity.id] = nil
         end
     end
 end


### PR DESCRIPTION
This might not be a supported use-case but most of it works and it's an easy fix. 

When sub-classing Entity, like `Player = class("Player", Entity)`, removing entitites or their components  fails because of the `.class.name == 'Entity'` checks in System, used to check if the system.targets is a list of entities or is grouped by categories. 

This changes the check to `type == string`, already used in the code for the same purpose. 
