### PR TITLE
Add Entity function to clear all components

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Adds the component to this particular entity. If there already exists a componen
 
 Removes a component from this particular entity.
 
-#### Entity:clearComponents()
+#### Entity:removeAll()
 
 Removes all components from this particular entity.
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Adds the component to this particular entity. If there already exists a componen
 
 Removes a component from this particular entity.
 
+#### Entity:clearComponents()
+
+Removes all components from this particular entity.
+
 #### Entity:has(Name)
 - **name** (String) - Name of the component class
 

--- a/spec/entity_spec.lua
+++ b/spec/entity_spec.lua
@@ -49,6 +49,19 @@ describe('Entity', function()
         entity:add(testComponent)
         entity:remove('TestComponent')
     end)
+	
+	it(':clearComponents() removes all Components', function()
+        entity:add(testComponent)
+		entity:add(testComponent1)
+        entity:clearComponents()
+		components = entity:getComponents()
+		
+		local count = 0
+        for _, __ in pairs(components) do
+            count = count + 1
+        end
+        assert.True(count == 0)
+    end)
 
     it(':remove() prints debug message if Component does not exist', function()
         local debug_spy = spy.on(lovetoys, 'debug')

--- a/spec/entity_spec.lua
+++ b/spec/entity_spec.lua
@@ -49,14 +49,14 @@ describe('Entity', function()
         entity:add(testComponent)
         entity:remove('TestComponent')
     end)
-	
-	it(':clearComponents() removes all Components', function()
+
+    it(':removeAll() removes all Components', function()
         entity:add(testComponent)
-		entity:add(testComponent1)
-        entity:clearComponents()
-		components = entity:getComponents()
-		
-		local count = 0
+        entity:add(testComponent1)
+        entity:removeAll()
+        components = entity:getComponents()
+
+        local count = 0
         for _, __ in pairs(components) do
             count = count + 1
         end

--- a/src/Entity.lua
+++ b/src/Entity.lua
@@ -59,7 +59,7 @@ function Entity:remove(name)
 end
 
 -- Removes all components from the entity.
-function Entity:clearComponents()
+function Entity:removeAll()
     self.components = {}
 end
 

--- a/src/Entity.lua
+++ b/src/Entity.lua
@@ -58,6 +58,11 @@ function Entity:remove(name)
     end
 end
 
+-- Removes all components from the entity.
+function Entity:clearComponents()
+    self.components = {}
+end
+
 function Entity:setParent(parent)
     if self.parent then self.parent.children[self.id] = nil end
     self.parent = parent


### PR DESCRIPTION
Removes all components added to a entity. Quicker than getting all components, and removing one by one.