### PR TITLE
Added option to use own copy of middleclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following table lists all available options:
 | --- | --- | --- | --- |
 | debug | boolean | false | Makes lovetoys print warnings and notifications to stdout. |
 | globals | boolean | false | If true, lovetoys will make all its classes available via the global namespace. (e.g. Entity instead of lovetoys.Entity) |
+| middleclassPath | string | nil | Path to user's copy of middleclass |
 
 **Note:** Once you've called `initialize`, the configuration will be the same every time you `require('lovetoys.lovetoys')`.
 

--- a/lovetoys.lua
+++ b/lovetoys.lua
@@ -11,7 +11,7 @@ end
 
 local function populateNamespace(ns)
     -- Requiring class
-    ns.class = require(folderOfThisFile .. 'lib.middleclass')
+    ns.class = require(lovetoys.config.middleclassPath or folderOfThisFile .. 'lib.middleclass')
 
     -- Requiring util functions
     ns.util = require(folderOfThisFile .. "src.util")


### PR DESCRIPTION
This can help when you want to use your own modified copy of middleclass without modifying lovetoys code/ replacing ```lib/middleclass.lua``` file.
Option name is up to you, if you have something better in mind. 